### PR TITLE
Add tooltip for BusinessList map icons

### DIFF
--- a/src/components/BusinessItem.vue
+++ b/src/components/BusinessItem.vue
@@ -5,9 +5,11 @@
       <div class="media">
         <!-- Add icon if saved -->
         <div class="media-left">
-          <figure class="image is-48x48" @click="clicked(item.latlng)">
-            <a href="#"><img :src="icons[item.zone]" :alt="item.title"/></a>
-          </figure>
+          <b-tooltip position="is-left" label="Go to this business on the map" :always="d_persistentTooltip" animated>
+            <figure @mouseenter="handleIconHover" class="image is-48x48" @click="clicked(item.latlng)">
+              <a href="#"><img :src="icons[item.zone]" :alt="item.title"/></a>
+            </figure>
+          </b-tooltip>
         </div>
         <div class="media-content">
           <p class="title is-4">
@@ -81,7 +83,8 @@ export default {
         require("../assets/dark-red.png"),
         require("../assets/dark-green.png"),
         require("../assets/dark-yellow.png")
-      ]
+      ],
+      d_persistentTooltip: false
     };
   },
 
@@ -89,6 +92,10 @@ export default {
     item: {
       type: Object,
       required: true
+    },
+    persistentTooltip: {
+      type: Boolean,
+      required: false
     }
   },
 
@@ -116,6 +123,14 @@ export default {
   methods: {
     clicked(value) {
       this.$emit("clicked", value);
+    },
+    handleIconHover() {
+      this.d_persistentTooltip = false;
+    }
+  },
+  mounted() {
+    if(this.persistentTooltip) {
+      this.d_persistentTooltip = true;
     }
   }
 };

--- a/src/components/BusinessList.vue
+++ b/src/components/BusinessList.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
-    <div class="mt-4" v-for="item in items" :key="item.BID">
-      <business-item @clicked="clicked" :item="item" />
+    <div class="mt-4" v-for="(item, i) in items" :key="item.BID">
+      <business-item @clicked="clicked" :item="item" :persistent-tooltip="i === 0" />
     </div>
   </section>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -95,10 +95,6 @@
           </b-field>
         </section>
 
-        <b-notification :closable="false" has-icon icon="information">
-          Click a pin to go to that item on the map.
-        </b-notification>
-
         <business-list class="mt-4" :items="filtered" @clicked="setCenter" />
       </div>
     </div>


### PR DESCRIPTION
Removes the information box below the Business List filters that says "Click a pin to go to that item on the map." and replaces it with a tooltip on the Business Item component. 

The first BusinessItem in the Business List will have a persistent tooltip until the user places their mouse over it, at which point the tooltip will only appear again on mouseenter. 

![image](https://user-images.githubusercontent.com/26944805/85420656-5b1a7000-b528-11ea-81c9-c843c8416eb3.png)
